### PR TITLE
chroot içine efivarfs de bağla

### DIFF
--- a/yali/storage/formats/filesystem.py
+++ b/yali/storage/formats/filesystem.py
@@ -1176,6 +1176,16 @@ class DebugFilesystem(NoDevFilesystem):
 
 register_device_format(DebugFilesystem)
 
+class EfiVarFilesystem(NoDevFilesystem):
+    _type = "efivarfs"
+    _mountOptions = ["efivarfs", "defaults"]
+
+    @property
+    def supported(self):
+        return yali.util.isEfi()
+
+register_device_format(EfiVarFilesystem)
+
 class ProcFilesystem(NoDevFilesystem):
     _type = "proc"
     _defaultMountOptions = ["nosuid", "noexec"]

--- a/yali/storage/storageset.py
+++ b/yali/storage/storageset.py
@@ -199,6 +199,7 @@ class StorageSet(object):
         self.active = False
         self._dev = None
         self._debugfs = None
+        self._efivarfs = None
         self._sysfs = None
         self._proc = None
         self._devshm = None
@@ -238,6 +239,15 @@ class StorageSet(object):
                                  device="debugfs",
                                  mountpoint="/sys/kernel/debug"))
         return self._debugfs
+
+    @property
+    def efivarfs(self):
+        if not self._efivarfs and yali.util.isEfi():
+            self._efivarfs = NoDevice(
+                format=getFormat("efivarfs",
+                                 device="efivarfs",
+                                 mountpoint="/sys/firmware/efi/efivars"))
+        return self._efivarfs
 
     @property
     def proc(self):
@@ -609,6 +619,10 @@ class StorageSet(object):
         devices = sorted(self.mountpoints.values(),
                          key=lambda d: d.format.mountpoint)
         devices += self.swapDevices
+
+        if yali.util.isEfi():
+            devices += self.efivarfs
+
         devices.extend([self.devshm, self.debugfs, self.sysfs, self.proc])
         for device in devices:
             # why the hell do we put swap in the fstab, anyway?


### PR DESCRIPTION
Olay şöyle: GRUB2, efibootmgr gibi araçların bir sistemin EFI değişkenlerini ayarlamak için /sys/firmware/efi/efivars içinde efivarfs tarzında bir dosya sistemine ihtiyaçları var. Bu dizin, MÜDÜR'le başlatılmış UEFI sistemlerde otomatik olarak bağlanıyor ancak bu durum sysfs'in içine ayriyeten bağlanmış olduğu konumlar için söz konusu değil. Zaten benzer bir hamle debugfs için yapılıyor, dolayısıyla düzgün bir şekilde yapıldığında efivarfs de aynı şekilde bağlanılabilir.

Paketleme yapabileceğim hazır bir ortamım ve zamanım henüz yok, dolayısıyla mümkünse sizin paketleyip test etmenizi şiddetle tavsiye ederim.