### PR TITLE
fixup! chroot içine efivarfs de bağla

### DIFF
--- a/yali/storage/storageset.py
+++ b/yali/storage/storageset.py
@@ -621,7 +621,7 @@ class StorageSet(object):
         devices += self.swapDevices
 
         if yali.util.isEfi():
-            devices += self.efivarfs
+            devices.append(self.efivarfs)
 
         devices.extend([self.devshm, self.debugfs, self.sysfs, self.proc])
         for device in devices:


### PR DESCRIPTION
Bir önceki değişikliğimde yaptığım bir hatadan dolayı YALI kurulumda "iterable" olmadığı için hata veriyordu. Bu değişiklik bunu düzeltmeyi hedefliyor.

Şu an yapım aşamasında ve test edilmesi şart. Bunun çalıştığından emin olmak lazım.