### PR TITLE
Fix the definition of hostname in postinstall step

### DIFF
--- a/yali/postinstall.py
+++ b/yali/postinstall.py
@@ -108,10 +108,11 @@ def setHostName():
     if yali.util.check_link() and ctx.installData.hostName:
         ctx.logger.info("Setting hostname %s" % ctx.installData.hostName)
         ctx.link.Network.Stack["baselayout"].setHostName(unicode(ctx.installData.hostName))
-        if ctx.flags.install_type == ctx.STEP_FIRST_BOOT:
-            yali.util.run_batch("hostname", [unicode(ctx.installData.hostName)])
-            yali.util.run_batch("update-environment")
-            ctx.logger.info("Updating environment...")
+        with open(os.path.join(ctx.consts.target_dir, "etc/hostname"), "w") as hostnameconfig:
+            hostnameconfig.write("%s" % ctx.installData.hostName)
+
+        yali.util.run_batch("update-environment")
+        ctx.logger.info("Updating environment...")
         return True
     else:
         ctx.logger.debug("Setting hostname execution failed.")


### PR DESCRIPTION
The previous approach has been failing and will fail all the time. Let's go the Arch Linux route and set it by writing directly into /etc/hostname instead. Also removed the condition for the write operation so it will work just fine.

PR notu: Kendim test ettim ve düzgün çalıştığını doğruladım. Bundan önce de yerel olarak direkt komut satırı yöntemi denemiştim ama pek içime sinmemişti. Python'a yerli yapmak hem işleri çok daha kolaylaştırır gibime geliyor.

PR notu 2: Bu kodu kendim düşünerek yazdım. İngilizce mesaj yazmamın sebebi uyumluluk olsun diye.