### PR TITLE
fixup!(2) chroot içine efivarfs de bağla

### DIFF
--- a/yali/storage/formats/filesystem.py
+++ b/yali/storage/formats/filesystem.py
@@ -1173,7 +1173,7 @@ register_device_format(DebugFilesystem)
 
 class EfiVarFilesystem(NoDevFilesystem):
     _type = "efivarfs"
-    _mountOptions = ["efivarfs", "defaults"]
+    _mountOptions = ["defaults"]
 
     @property
     def supported(self):


### PR DESCRIPTION
Burada düzeltilen hata YALI Kurtarıcı'nın bozulmasına neden oluyordu.
Bunun olmasının sebebi de buradaki bağlama seçeneklerinin FSTAB'a da
yazılmasından ve, böyle bir seçenek olmadığı için, bağlanamamasına
neden oluyordu.

Bu düzeltme aynı zamanda kurulu sistemde açılışta görünen efivarfs
bağlama hatasını da gidermekte.
