### PR TITLE
Increase partition size for /boot

### DIFF
--- a/yali/storage/partitioning.py
+++ b/yali/storage/partitioning.py
@@ -1518,7 +1518,7 @@ def defaultPartitioning(storage, quiet=0, asVol=True):
                                   asVol=asVol, requiredSpace=50*1024)]
 
     bootreq = PartitionSpec(mountpoint="/boot", fstype=storage.defaultFSType,
-                            size=500, weight=weight(mountpoint="/boot"))
+                            size=1000, weight=weight(mountpoint="/boot"))
     autorequests.append(bootreq)
 
     (minswap, maxswap) = yali.util.swap_suggestion(quiet=quiet)


### PR DESCRIPTION
Kernels, ucode and GRUB are stored on /boot and since the sizes
of the kernel is becoming gigantic for our tiny little /boot,
we can't store more than one kernel there anymore considering
GRUB and ucode too. Bump the size to 1 GiB as suggested by Arch
Linux's installation instructions so that we can have more room
for storing those.

Increasing /boot size should also resolve cryptic errors like
"unknown file format" when upgrading ucodes via `pisi up`.

-----

Çekirdekler, ucode ve GRUB /boot içinde tutuluyor ve çekirdeğin
boyutu bizim minik /boot için aşırı büyük hale geliyor olduğundan
GRUB ve ucode'u da düşünürsek orada birden fazla çekirdek
depolayamayız. Arch Linux'un kurulum adımları tarafından da
önerildiği gibi boyutu 1 GiB'e artır ki bunları depolamak için
daha büyük bir alanımız olsun.

/boot boyutu artırmak `pisi up` kullanarak ucode'ları güncellerken
çıkan "bilinmeyen dosya formatı" gibi şifreli hataları da çözmeli.
